### PR TITLE
Port to Linux kernel 6.18 HDA codec API

### DIFF
--- a/KERNEL-6.18-PORT.md
+++ b/KERNEL-6.18-PORT.md
@@ -1,0 +1,38 @@
+# Port to Linux Kernel 6.18 HDA Codec API
+
+This patch updates the out-of-tree CS8409 codec driver to compile against
+Linux kernel 6.18+, which introduced breaking changes to the HDA codec API.
+
+## Changes
+
+### API Removals in Kernel 6.18
+
+- **`hda_codec_ops.free`** field was removed; replaced by **`.remove`**
+- **`hda_codec.patch_ops`** field was removed; codec ops are now set at the
+  driver level via `hda_codec_driver.ops`
+- **`HDA_CODEC_ENTRY()`** macro was removed; replaced by **`HDA_CODEC_ID()`**
+- **`snd_hda_gen_free()`** was renamed to **`snd_hda_gen_remove()`**
+
+### How This Patch Addresses Them
+
+- A new `codec_ops` pointer was added to `struct cs8409_spec` to store
+  per-codec ops (Dell vs Apple paths use different callbacks)
+- Driver-level dispatch functions (`cs8409_dispatch_*`) forward calls to the
+  per-codec ops stored in `spec->codec_ops`
+- A `.probe` callback wraps the existing `patch_cs8409()` function
+- All `.free` references updated to `.remove`
+- All `snd_hda_gen_free` calls updated to `snd_hda_gen_remove`
+
+## Build Instructions
+
+The kernel must be built with the LLVM toolchain (CachyOS default). Use:
+
+```bash
+make CC=clang LD=ld.lld
+sudo make CC=clang LD=ld.lld install
+```
+
+## Tested On
+
+- CachyOS with kernel 6.18.8-3-cachyos
+- MacBook Pro 13,1 (CS8409 + CS42L83)

--- a/hda_generic.h
+++ b/hda_generic.h
@@ -311,7 +311,7 @@ enum {
 int snd_hda_gen_spec_init(struct hda_gen_spec *spec);
 
 int snd_hda_gen_init(struct hda_codec *codec);
-void snd_hda_gen_free(struct hda_codec *codec);
+void snd_hda_gen_remove(struct hda_codec *codec);
 
 int snd_hda_get_path_idx(struct hda_codec *codec, struct nid_path *path);
 struct nid_path *snd_hda_get_path_from_idx(struct hda_codec *codec, int idx);

--- a/patch_cirrus_apple.h
+++ b/patch_cirrus_apple.h
@@ -1396,9 +1396,8 @@ static int cs_8409_apple_init(struct hda_codec *codec)
 static int cs_8409_apple_resume(struct hda_codec *codec)
 {
         myprintk("snd_hda_intel: cs_8409_apple_resume\n");
-        // code copied from default resume patch ops
-	if (codec->patch_ops.init)
-		codec->patch_ops.init(codec);
+        // call init directly during resume
+	cs_8409_apple_init(codec);
 	snd_hda_regmap_sync(codec);
         myprintk("snd_hda_intel: end cs_8409_apple_resume\n");
         return 0;
@@ -1696,7 +1695,7 @@ void cs_8409_cs42l83_jack_unsol_event(struct hda_codec *codec, unsigned int res)
 
 // have an explict one for 8409
 // cs_free is just a definition
-//#define cs_8409_apple_free		snd_hda_gen_free
+//#define cs_8409_apple_free		snd_hda_gen_remove
 
 void cs_8409_apple_free(struct hda_codec *codec)
 {
@@ -1710,7 +1709,7 @@ void cs_8409_apple_free(struct hda_codec *codec)
 
 	//del_timer(&cs_8409_hp_timer);
 
-	snd_hda_gen_free(codec);
+	snd_hda_gen_remove(codec);
 }
 
 
@@ -1720,7 +1719,7 @@ static const struct hda_codec_ops cs_8409_apple_patch_ops = {
 	.build_controls = cs_8409_apple_build_controls,
 	.build_pcms = cs_8409_apple_build_pcms,
 	.init = cs_8409_apple_init,
-	.free = cs_8409_apple_free,
+	.remove = cs_8409_apple_free,
 	.unsol_event = cs_8409_cs42l83_jack_unsol_event,
 #ifdef CONFIG_PM
         .resume = cs_8409_apple_resume,
@@ -2588,10 +2587,10 @@ static int patch_cs8409_apple(struct hda_codec *codec)
 
         if (explicit)
                {
-               //codec->patch_ops = cs_8409_apple_patch_ops_explicit;
+               //spec->codec_ops = &cs_8409_apple_patch_ops_explicit;
                }
         else
-               codec->patch_ops = cs_8409_apple_patch_ops;
+               spec->codec_ops = &cs_8409_apple_patch_ops;
 
 
 	// not sure about these
@@ -2730,10 +2729,10 @@ static int patch_cs8409_apple(struct hda_codec *codec)
 #else
         if (explicit)
                {
-               //codec->patch_ops = cs_8409_apple_patch_ops_explicit;
+               //spec->codec_ops = &cs_8409_apple_patch_ops_explicit;
                }
         else
-               codec->patch_ops = cs_8409_apple_patch_ops;
+               spec->codec_ops = &cs_8409_apple_patch_ops;
 #endif
 
         // moved to post auto config

--- a/patch_cs8409.h
+++ b/patch_cs8409.h
@@ -341,6 +341,7 @@ struct sub_codec {
 
 struct cs8409_spec {
 	struct hda_gen_spec gen;
+	const struct hda_codec_ops *codec_ops;
 	struct hda_codec *codec;
 
 	struct sub_codec *scodecs[CS8409_MAX_CODECS];


### PR DESCRIPTION
## Summary
- Update driver to compile against kernel 6.18+ which removed `hda_codec.patch_ops`, `hda_codec_ops.free`, `HDA_CODEC_ENTRY()`, and renamed `snd_hda_gen_free()`
- Add driver-level dispatch ops that forward to per-codec ops stored in `spec->codec_ops`
- Add `.probe` callback and restructure driver registration for the new `hda_codec_driver` API

## Test plan
- [x] Builds successfully with `make CC=clang LD=ld.lld` on CachyOS kernel 6.18.8-3-cachyos
- [x] Module loads with correct metadata (`modinfo` verified)
- [x] Test audio playback on MacBook Pro 13,1
- [ ] Test headphone jack detection
- [ ] Test suspend/resume cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)